### PR TITLE
Changed socket-timeout to 15 minutes in both presto hcls.

### DIFF
--- a/nomad-jobs/presto-connect.hcl
+++ b/nomad-jobs/presto-connect.hcl
@@ -93,7 +93,7 @@ EOF
               hive.s3.use-instance-credentials=false
               hive.s3.max-connections=5000
               hive.s3.max-error-retries=100
-              hive.s3.socket-timeout=31m
+              hive.s3.socket-timeout=15m
               hive.s3.ssl.enabled=false
               hive.metastore-timeout=1m
               hive.s3.path-style-access=true

--- a/nomad-jobs/presto.hcl
+++ b/nomad-jobs/presto.hcl
@@ -111,7 +111,7 @@ hive.s3.aws-secret-key=minioadmin
 hive.s3.endpoint=http://{{ env "NOMAD_UPSTREAM_ADDR_minio" }}
 hive.s3.path-style-access=true
 hive.s3.ssl.enabled=false
-hive.s3.socket-timeout=1m
+hive.s3.socket-timeout=15m
 EOH
       }
       template {


### PR DESCRIPTION
As title says. Changed in `presto-connect.hcl` even though it's not in use, in case it remains as an example of multinode presto setup. 
Closes #12 