### PR TITLE
Consul check to see if testdata exists and is available in metastore

### DIFF
--- a/nomad-jobs/example-csv.hcl
+++ b/nomad-jobs/example-csv.hcl
@@ -31,7 +31,7 @@ job "example-csv" {
         # needs to use '|| exit 2' because beeline returns 1 if table doesn't exist, which will be marked as
         # 'warning' in consul
         args = ["-c", "beeline -u \"jdbc:hive2://localhost:10000/default;auth=noSasl\" -n hive -p hive -e \"SELECT * FROM default.iris LIMIT 2\" || exit 2"]
-        interval = "10s"
+        interval = "60s"
         timeout = "25s"
       }
     }


### PR DESCRIPTION
Example of health-check in example-csv.hcl that checks if table exists.
 
@fredrikhgrelland we would like your thoughts. 

Nikita and I discussed if this would be useful. @zhenik, if I understood you correctly, you're not sure if we should include this, because a successful run of the `example-csv` job already implies that data is available in metastore? 

I think this should be included. Although the availability of data might not be a service in itself, I do argue it functions as a "service" to other services because they might depend on the availability of  it to work. If there is no chance of this data being deleted, and the only case this data would NOT be available is if metastore goes down, then we don't need this check. 

Closes #17 