### PR TITLE
Fixing create buckets in minio

### DIFF
--- a/resources/nomad-jobs/hive-connect.hcl
+++ b/resources/nomad-jobs/hive-connect.hcl
@@ -239,6 +239,10 @@ job "hive" {
     }
     task "waitfor-minio-has-required-buckets" {
       # `default` & `hive` buckets
+      restart {
+        attempts = 100
+        delay    = "1s"
+      }
       lifecycle {
         hook = "prestart"
       }
@@ -249,7 +253,7 @@ job "hive" {
           "/bin/sh", "-c",
           # adding config command could fail, if minio not available or bad credentials
           # if buckets already exists => exit 0
-          "mc config host add myminio http://${NOMAD_UPSTREAM_ADDR_minio} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} && mc mb myminio/hive || true && mc mb myminio/default || true"
+          "mc config host add myminio http://${NOMAD_UPSTREAM_ADDR_minio} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} || exit 2 && mc mb myminio/hive || true && mc mb myminio/default || true"
         ]
       }
       template {


### PR DESCRIPTION
Now forcing an exit 2 if the task fails to add the minio as host (was 1 before, which meant the task kept on going and eventually exiting with 0).

Retries are way overkill, but wanted to get something up quickly so I can keep working on adding a vagrantfile. This is a blocker to that.

Closes #51 