### PR TITLE
Consul commands in makefile now use the box's consul (no need for consul on local machine)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 *.tfstate.backup
 *.tfstate
 .terraform
-/tmp
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.tfstate.backup
 *.tfstate
 .terraform
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # versions
 PRESTO_VERSION := 333
+export PATH := $(shell pwd)/tmp:$(PATH)
+
 
 # start commands
 up:
@@ -9,19 +11,27 @@ test:
 	ANSIBLE_ARGS='--extra-vars "mode=test"' vagrant up --provision
 
 # clean commands
-clean: 
+destroy-box:
 	vagrant destroy -f
 
+remove-tmp:
+	rm -rf ./tmp
+
+clean: destroy-box remove-tmp
+
 # start proxies
-connect-to-hive:
+copy-consul:
+	if [ ! -f "./tmp/consul" ]; then mkdir -p ./tmp; vagrant ssh -c "cp /usr/local/bin/consul /vagrant/tmp/consul"; fi;
+
+connect-to-hive: copy-consul
 	consul connect proxy -service user -upstream hive-server:8070 -log-level debug
-connect-to-presto:
+connect-to-presto: copy-consul
 	consul connect proxy -service user -upstream presto:8080 -log-level debug
-connect-to-minio:
+connect-to-minio: copy-consul
 	consul connect proxy -service user -upstream minio:8090 -log-level debug
-connect-to-hue:
+connect-to-hue: copy-consul
 	consul connect proxy -service user -upstream hue-server:8888 -log-level debug
-connect-to-sqlpad:
+connect-to-sqlpad: copy-consul
 	consul connect proxy -service user -upstream sqlpad-server:3000 -log-level debug
 
 download-presto-cli:


### PR DESCRIPTION
I don't like the fact that I now add a tmp-folder to the repo without cleaning up unless `make clean` is ran. Ideally a `rm -rf ./tmp` would run as soon as the proxy is terminated. I couldn't find an easy way to run something _after_ the `consul connect proxy ...` command is interrupted. If anyone has any good ideas, please let me know

closes #93 